### PR TITLE
Open & Save individual Paths. Run as an app

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@
 plugins {
     // Apply the java-library plugin to add support for Java Library
     id 'java-library'
+    id 'application'
 }
 
 repositories {
@@ -26,4 +27,8 @@ dependencies {
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'
+}
+
+application {
+    mainClassName = 'com.team319.ui.BobTrajectoryApp'
 }

--- a/src/main/java/com/team254/lib/trajectory/Spline.java
+++ b/src/main/java/com/team254/lib/trajectory/Spline.java
@@ -59,7 +59,7 @@ public class Spline {
 
 	public static boolean reticulateSplines(DraggableWaypoint start, DraggableWaypoint goal,
 			Spline result, Type type) {
-		return reticulateSplines(start.getX(), start.getY(), start.getHeading(), goal.getX(), goal.getY(), goal.getHeading(), result, type);
+		return reticulateSplines(start.getX(), start.getY(), -start.getHeading(), goal.getX(), goal.getY(), -goal.getHeading(), result, type);
 	}
 
 	public static boolean reticulateSplines(double x0, double y0, double theta0, double x1, double y1, double theta1,

--- a/src/main/java/com/team319/io/ConfigExporter.java
+++ b/src/main/java/com/team319/io/ConfigExporter.java
@@ -1,11 +1,19 @@
 package com.team319.io;
 
 import com.team319.trajectory.RobotConfig;
+import java.io.File;
 
 public class ConfigExporter {
 
     public static void exportConfig() {
-        
+        exportConfig(new File("src/main/java/frc/paths"));
+    }
+
+    /**
+     * 
+     * @param file - The Path where the config file is to be stored
+     */
+    public static void exportConfig(File file) {
         StringBuilder data = new StringBuilder();
 			
         data.append(RobotConfig.length).append(System.lineSeparator());
@@ -15,6 +23,6 @@ public class ConfigExporter {
         data.append(RobotConfig.maxAcceleration).append(System.lineSeparator());
         data.append(RobotConfig.exportType).append(System.lineSeparator());
 
-        FilePrinter.write("src\\main\\java\\frc\\paths\\", "config.txt", data.toString());
+        FilePrinter.write(file.getAbsolutePath(), "/config.txt", data.toString());
     }
 }

--- a/src/main/java/com/team319/io/ConfigImporter.java
+++ b/src/main/java/com/team319/io/ConfigImporter.java
@@ -12,8 +12,16 @@ import com.team319.trajectory.RobotConfig;
 
 public class ConfigImporter {
 
-    public static void importConfig() {
-        File file = new File( "src\\main\\java\\frc\\paths\\config.txt");
+    /**
+     * 
+     * @param file - The directory where the config file is found
+     */
+    public static void importConfig(File file) {
+        if (null == file){
+            file = new File( "src/main/java/frc/paths/config.txt");
+        } else {
+            file = new File(file, "config.txt");
+        }
         if (!file.exists()) {
             return;
         }

--- a/src/main/java/com/team319/io/FilePrinter.java
+++ b/src/main/java/com/team319/io/FilePrinter.java
@@ -9,15 +9,21 @@ public class FilePrinter {
     public static void write(String fileLocation, String fileName, String data) {
         try {
             File file = new File(fileLocation + fileName);
+            System.out.println("Saving to file: " + file.getCanonicalPath());
             file.getParentFile().mkdirs();
-            // if file doesnt exists, then create it
+            // if file doesn't exist, then create it
             if (!file.exists()) {
-                file.createNewFile();
+                if(!file.createNewFile()) {
+                    System.out.println("Could not create output file "+file.getCanonicalPath());
+                    return;
+                }                
             }
             FileWriter fw = new FileWriter(file.getAbsoluteFile());
             BufferedWriter bw = new BufferedWriter(fw);
             bw.write(data);
             bw.close();
-        } catch (Exception e) {}
+        } catch (Exception e) {
+            System.out.println("Problem printing file: " + e);
+        }
     }
 }

--- a/src/main/java/com/team319/io/PathExporter.java
+++ b/src/main/java/com/team319/io/PathExporter.java
@@ -3,9 +3,11 @@ package com.team319.io;
 import java.util.List;
 
 import com.team319.trajectory.BobPath;
+import java.io.File;
 
 public class PathExporter {
 
+    private static final String defaultPath = "src/main/java/frc/paths/";
     public static void exportPaths(List<BobPath> paths) {
         
         StringBuilder data = new StringBuilder();
@@ -13,6 +15,14 @@ public class PathExporter {
         for (BobPath path : paths) {
             data.append(path.toString());
         }
-        FilePrinter.write("src\\main\\java\\frc\\paths\\", "Paths.txt", data.toString());
+        FilePrinter.write(defaultPath, "Paths.txt", data.toString());
+    }
+
+    public static void exportPath(BobPath path, File file) {
+        try {
+            FilePrinter.write(file.getAbsolutePath(),"/" + path.getName() + ".txt", path.toString());
+        } catch (Exception e) {
+            System.out.println("Execption trying to save a path. " + e + " " + e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/team319/io/PathImporter.java
+++ b/src/main/java/com/team319/io/PathImporter.java
@@ -13,8 +13,12 @@ import com.team319.ui.Plotter;
 public class PathImporter {
 
     public static List<Plotter> importPaths() {
+        File file = new File( "src/main/java/frc/paths/Paths.txt");
+        return importPaths(file);
+    }
+
+    public static List<Plotter> importPaths(File file) {
         List<Plotter> paths = new ArrayList<>();
-        File file = new File( "src\\main\\java\\frc\\paths\\Paths.txt");
         if (!file.exists()) {
             return paths;
         }

--- a/src/main/java/com/team319/io/TrajectoryExporter.java
+++ b/src/main/java/com/team319/io/TrajectoryExporter.java
@@ -1,6 +1,7 @@
 package com.team319.io;
 
 import java.util.List;
+import java.io.File;
 
 import com.team254.lib.trajectory.PathGenerator;
 import com.team254.lib.trajectory.Trajectory;
@@ -9,34 +10,56 @@ import com.team319.trajectory.BobPath;
 import com.team319.trajectory.RobotConfig;
 
 public class TrajectoryExporter {
+    private static final String defaultPathPath = "src/main/deploy/paths/";
+    private static final String defaultClassPath = "src/main/java/frc/paths/";
 
+    /**
+     * 
+     * @param paths - the list of paths to export
+     */
     public static void exportTrajectory(List<BobPath> paths) {
         for (BobPath path : paths) {
-            try {
-                Trajectory trajectory = PathGenerator.generateTrajectory(path.getWaypoints());
-                TrajectorySet trajectorySet = PathGenerator.makeLeftAndRightTrajectories(trajectory);
-                switch (RobotConfig.exportType) {
-                    case CLASS:
-                        exportToClass(path.getName(), trajectorySet);
-                        break;
-                    case FILE:
-                        exportToFile(path.getName(), trajectorySet);
-                        break;
-                }
-                
-            } catch (Exception e) { 
-                e.printStackTrace();
-            }
+            exportTrajectory(path, null);
         }
     }
 
-    private static void exportToFile(String pathName, TrajectorySet set) {
-        FilePrinter.write("src\\main\\deploy\\paths\\", pathName + ".left.csv", set.left.toString());
-        FilePrinter.write("src\\main\\deploy\\paths\\", pathName + ".right.csv", set.right.toString());
-        FilePrinter.write("src\\main\\deploy\\paths\\", pathName + ".center.csv", set.center.toString());
+    /**
+     * 
+     * @param path - the BobPath to export
+     * @param file - the directory to save the paths or class to
+     */
+    public static void exportTrajectory(BobPath path, File file) {
+        try {
+            Trajectory trajectory = PathGenerator.generateTrajectory(path.getWaypoints());
+            TrajectorySet trajectorySet = PathGenerator.makeLeftAndRightTrajectories(trajectory);
+            switch (RobotConfig.exportType) {
+                case CLASS:
+                    if (null == file) {
+                        exportToClass(defaultClassPath, path.getName(), trajectorySet);
+                    } else {
+                        exportToClass(file.getAbsolutePath() + "/", path.getName(), trajectorySet);                    
+                    }
+                    break;
+                case FILE:
+                    if (null == file) {
+                        exportToFile(defaultPathPath, path.getName(), trajectorySet);
+                    } else {
+                        exportToFile(file.getAbsolutePath() + "/", path.getName(), trajectorySet);
+                    }
+                    break;
+            }            
+        } catch (Exception e) { 
+            e.printStackTrace();
+        }
     }
 
-    private static void exportToClass(String pathName, TrajectorySet set) {
-        FilePrinter.write("src\\main\\java\\frc\\paths\\", pathName + ".java", ClassExporter.createClass(set, pathName));
+    private static void exportToFile(String pathPath, String pathName, TrajectorySet set) {
+        FilePrinter.write(pathPath, pathName + ".left.csv", set.left.toString());
+        FilePrinter.write(pathPath, pathName + ".right.csv", set.right.toString());
+        FilePrinter.write(pathPath, pathName + ".center.csv", set.center.toString());
+    }
+
+    private static void exportToClass(String pathPath, String pathName, TrajectorySet set) {
+        FilePrinter.write(pathPath, pathName + ".java", ClassExporter.createClass(set, pathName));
     }
 }

--- a/src/main/java/com/team319/ui/OpenButton.java
+++ b/src/main/java/com/team319/ui/OpenButton.java
@@ -1,0 +1,49 @@
+package com.team319.ui;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Stroke;
+
+import javax.swing.JButton;
+
+public class OpenButton extends JButton {
+
+    private static final long serialVersionUID = 1L;
+    private Color color = new Color(32, 32, 32);
+    private Color pressedColor = new Color(64, 64, 64);
+    private Stroke stroke = new BasicStroke(5);
+    private Font font = new Font("times", Font.PLAIN, 40);
+
+    public OpenButton() {
+        super();
+        enableInputMethods(true);
+        setContentAreaFilled(false);
+    }
+
+    @Override
+    public void paintComponent(Graphics g) {
+        Graphics2D gc = (Graphics2D) g;
+        if (getModel().isPressed()) {
+            gc.setColor(pressedColor);
+        } else {
+            gc.setColor(color);
+        }
+        gc.fillOval(0, 0, 50, 50);
+        gc.setColor(Color.WHITE);
+        gc.setStroke(stroke);
+        gc.setFont(font);
+        gc.drawString("O", 12, 40);
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+        return new Dimension(50, 50);
+    }
+
+    @Override
+    public void paintBorder(Graphics g) { }
+}

--- a/src/main/java/com/team319/ui/SaveButton.java
+++ b/src/main/java/com/team319/ui/SaveButton.java
@@ -1,0 +1,49 @@
+package com.team319.ui;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Stroke;
+
+import javax.swing.JButton;
+
+public class SaveButton extends JButton {
+
+    private static final long serialVersionUID = 1L;
+    private Color color = new Color(32, 32, 32);
+    private Color pressedColor = new Color(64, 64, 64);
+    private Stroke stroke = new BasicStroke(5);
+    private Font font = new Font("times", Font.PLAIN, 40);
+
+    public SaveButton() {
+        super();
+        enableInputMethods(true);
+        setContentAreaFilled(false);
+    }
+
+    @Override
+    public void paintComponent(Graphics g) {
+        Graphics2D gc = (Graphics2D) g;
+        if (getModel().isPressed()) {
+            gc.setColor(pressedColor);
+        } else {
+            gc.setColor(color);
+        }
+        gc.fillOval(0, 0, 50, 50);
+        gc.setColor(Color.WHITE);
+        gc.setStroke(stroke);
+        gc.setFont(font);
+        gc.drawString("S", 12, 40);
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+        return new Dimension(50, 50);
+    }
+
+    @Override
+    public void paintBorder(Graphics g) { }
+}


### PR DESCRIPTION
A few changes I made over the weekend:
1. Changed the file paths to remove "\\" and changed to the Java standard "/" so the library will work on OSes besides Windows.
2. Added the "application" plugin in build.gradle so the app can be run with "./gradlew run".
3. Added "Save" and "Open" buttons that allow individual paths to be saved/opened wherever the user wants. Writes all of the files - path definition, .csv or .java, and config.txt into the chosen directory. Opening a path imports the configuration at the same time. Closing the app will still ask if the user wants to save everything and behaves as before - writing to specific directories.
4. Changed "Spline" to use negative heading. This fixes the drawing of the splines on the screen. I have not confirmed that the newly generated paths/trajectories are correct. It could be that the drawing code needs to have all the headings reversed.